### PR TITLE
Updated FilerBuilder.cs, modified exctraction of propertyName from st…

### DIFF
--- a/ExpressionBuilder/Builders/FilterBuilder.cs
+++ b/ExpressionBuilder/Builders/FilterBuilder.cs
@@ -1,4 +1,4 @@
-﻿using ExpressionBuilder.Common;
+using ExpressionBuilder.Common;
 using ExpressionBuilder.Exceptions;
 using ExpressionBuilder.Interfaces;
 using System;
@@ -69,7 +69,7 @@ namespace ExpressionBuilder.Builders
         private Expression ProcessListStatement(ParameterExpression param, IFilterStatement statement)
         {
             var basePropertyName = statement.PropertyId.Substring(0, statement.PropertyId.IndexOf("["));
-            var propertyName = statement.PropertyId.Replace(basePropertyName, "").Replace("[", "").Replace("]", "");
+            var propertyName = statement.PropertyId.Substring(statement.PropertyId.IndexOf("["), statement.PropertyId.IndexOf("]"));
 
             var type = param.Type.GetProperty(basePropertyName).PropertyType.GetGenericArguments()[0];
             ParameterExpression listItemParam = Expression.Parameter(type, "i");


### PR DESCRIPTION
…atement

Before this fix, the propertyName param was extracted from statement replacing basePropertyName with empty string, this caused problems if the propertyName contained substring like basePropertyName; (ex. Contacts[ContactsNumber] ). Fixed