### PR TITLE
Fix AmbiguousMatchException for .Net Core 3.1

### DIFF
--- a/ExpressionBuilder/Configuration/Settings.cs
+++ b/ExpressionBuilder/Configuration/Settings.cs
@@ -1,10 +1,11 @@
 ﻿#if NETSTANDARD2_0
 using Microsoft.Extensions.Configuration;
 #endif
+using ExpressionBuilder.Common;
 using System;
 using System.Collections.Generic;
 using System.Configuration;
-using ExpressionBuilder.Common;
+using System.IO;
 
 namespace ExpressionBuilder.Configuration
 {
@@ -17,10 +18,9 @@ namespace ExpressionBuilder.Configuration
 #if (NETSTANDARD2_0 || NETSTANDARD2_1 || NETSTANDARD2_2)
 
             var builder = new ConfigurationBuilder()
-                .SetBasePath(AppContext.BaseDirectory)
-                .AddJsonFile("appsettings.json",
+                .AddJsonFile(Path.GetFullPath("./appsettings.json"),
                     optional: true,
-                    reloadOnChange: true);
+                    reloadOnChange: false);
 
             var _config = builder.Build();
 

--- a/ExpressionBuilder/ExpressionBuilder.csproj
+++ b/ExpressionBuilder/ExpressionBuilder.csproj
@@ -2,28 +2,24 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net452</TargetFrameworks>
-    <Authors>David Belmont</Authors>
-    <RepositoryUrl>https://github.com/dbelmont/ExpressionBuilder</RepositoryUrl>
+    <Authors>David Belmont, Majid Iqbal</Authors>
+    <RepositoryUrl>https://github.com/Akinzekeel/ExpressionBuilder</RepositoryUrl>
     <PackageIconUrl>https://raw.githubusercontent.com/dbelmont/ExpressionBuilder/master/ExpressionBuilder/ExpressionBuilder.png</PackageIconUrl>
-    <PackageProjectUrl>http://dbelmont.github.io/ExpressionBuilder/</PackageProjectUrl>
-    <PackageLicenseUrl>https://github.com/dbelmont/ExpressionBuilder/blob/master/LICENSE</PackageLicenseUrl>
-    <Copyright>David Belmont © 2019</Copyright>
+    <PackageProjectUrl>https://github.com/Akinzekeel/ExpressionBuilder</PackageProjectUrl>
+    <PackageLicenseUrl></PackageLicenseUrl>
+    <Copyright>David Belmont © 2019, Majid Iqbal</Copyright>
     <PackageTags>LINQ Lambda Expression Builder LINQ Database Queryable</PackageTags>
-    <PackageReleaseNotes>Main changes in this version:
-      • Added support for .NetStandard 2.0 (which should include support for .Net Core 2.0) (huge thanks to Joris Labie @labiej)
-      • 'FilterFactory' class added to offer a "non-generics" approach for creating filters (issue #25)
-      • Improved support for nested properties (issues #26 and #29)
-      • Added new 'NotIn' operator (issue #36)
-      • Fixed bug that used to throw an exception when using the `In` operator over a nullable property (issue #37)</PackageReleaseNotes>
+    <PackageReleaseNotes>This is a fork of dbelmont/LamdaExpressionBuilder. The fork is aimed towards .Net Core 3.1 and newer which may not work well with the original source code.</PackageReleaseNotes>
     <Description>This library basically provides you with a simple way to create lambda expressions to filter lists and database queries by delivering an easy-to-use fluent interface that enables the creation, storage and transmission of those filters.
 
       Useful to turn WebApi requests parameters into expressions, create advanced search screens with the capability to save and re-run those filters, among other things.
 </Description>
-    <AssemblyVersion>2.1.0.0</AssemblyVersion>
+    <AssemblyVersion>1.0.0.0</AssemblyVersion>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-    <Version>2.1.0-rc</Version>
+    <Version>1.0.0</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>LambdaExpressionBuilder</PackageId>
+    <FileVersion>1.0.0.0</FileVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|netstandard2.0|AnyCPU'">
     <DocumentationFile>C:\Dev\ExpressionBuilder\ExpressionBuilder\ExpressionBuilder.xml</DocumentationFile>

--- a/ExpressionBuilder/ExpressionBuilder.csproj
+++ b/ExpressionBuilder/ExpressionBuilder.csproj
@@ -17,7 +17,7 @@
     <AssemblyVersion>1.0.0.0</AssemblyVersion>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <Version>1.0.0</Version>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <PackageId>LambdaExpressionBuilder</PackageId>
     <FileVersion>1.0.0.0</FileVersion>
   </PropertyGroup>

--- a/ExpressionBuilder/Interfaces/IFilter.cs
+++ b/ExpressionBuilder/Interfaces/IFilter.cs
@@ -1,5 +1,5 @@
-﻿using System.Collections.Generic;
-using ExpressionBuilder.Common;
+﻿using ExpressionBuilder.Common;
+using System.Collections.Generic;
 
 namespace ExpressionBuilder.Interfaces
 {

--- a/ExpressionBuilder/Interfaces/IFilterStatementConnection.cs
+++ b/ExpressionBuilder/Interfaces/IFilterStatementConnection.cs
@@ -4,14 +4,14 @@
     /// Connects to FilterStatement together.
     /// </summary>
 	public interface IFilterStatementConnection
-	{
-		/// <summary>
-		/// Defines that the last filter statement will connect to the next one using the 'AND' logical operator.
-		/// </summary>
+    {
+        /// <summary>
+        /// Defines that the last filter statement will connect to the next one using the 'AND' logical operator.
+        /// </summary>
         IFilter And { get; }
         /// <summary>
         /// Defines that the last filter statement will connect to the next one using the 'OR' logical operator.
         /// </summary>
         IFilter Or { get; }
-	}
+    }
 }

--- a/ExpressionBuilder/Interfaces/IOperation.cs
+++ b/ExpressionBuilder/Interfaces/IOperation.cs
@@ -1,6 +1,6 @@
-﻿using System.ComponentModel.DataAnnotations;
+﻿using ExpressionBuilder.Common;
+using System.ComponentModel.DataAnnotations;
 using System.Linq.Expressions;
-using ExpressionBuilder.Common;
 
 namespace ExpressionBuilder.Interfaces
 {

--- a/ExpressionBuilder/Interfaces/IOperationHelper.cs
+++ b/ExpressionBuilder/Interfaces/IOperationHelper.cs
@@ -1,6 +1,6 @@
-﻿using System;
+﻿using ExpressionBuilder.Operations;
+using System;
 using System.Collections.Generic;
-using ExpressionBuilder.Operations;
 
 namespace ExpressionBuilder.Interfaces
 {

--- a/ExpressionBuilder/Operations/Contains.cs
+++ b/ExpressionBuilder/Operations/Contains.cs
@@ -1,4 +1,5 @@
 ﻿using ExpressionBuilder.Common;
+using System;
 using System.Linq.Expressions;
 using System.Reflection;
 
@@ -9,7 +10,13 @@ namespace ExpressionBuilder.Operations
     /// </summary>
     public class Contains : OperationBase
     {
-        private readonly MethodInfo stringContainsMethod = typeof(string).GetMethod("Contains", new[] { typeof(string) });
+        private readonly MethodInfo stringContainsMethod = typeof(string).GetMethod(
+            "Contains",
+            BindingFlags.DeclaredOnly | BindingFlags.Public | BindingFlags.Instance,
+            Type.DefaultBinder,
+            new[] { typeof(string) },
+            new ParameterModifier[0]
+        );
 
         /// <inheritdoc />
         public Contains()

--- a/ExpressionBuilder/Operations/OperationBase.cs
+++ b/ExpressionBuilder/Operations/OperationBase.cs
@@ -1,6 +1,6 @@
-﻿using System;
-using ExpressionBuilder.Common;
+﻿using ExpressionBuilder.Common;
 using ExpressionBuilder.Interfaces;
+using System;
 using System.Linq.Expressions;
 
 namespace ExpressionBuilder.Operations

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,45 @@
+# ASP.NET Core (.NET Framework)
+# Build and test ASP.NET Core projects targeting the full .NET Framework.
+# Add steps that publish symbols, save build artifacts, and more:
+# https://docs.microsoft.com/azure/devops/pipelines/languages/dotnet-core
+trigger:
+  paths:
+    exclude:
+      - '**/build-*.yml'
+
+pool:
+  vmImage: 'windows-latest'
+
+variables:
+  buildPlatform: 'Any CPU'
+  buildConfiguration: 'Release'
+
+steps:
+- task: NuGetToolInstaller@1
+
+- task: DotNetCoreCLI@2
+  displayName: 'Restore'
+  inputs:
+    command: 'restore'
+    projects: 'ExpressionBuilder/ExpressionBuilder.csproj'
+
+- task: DotNetCoreCLI@2
+  displayName: 'Build'
+  inputs:
+    command: 'build'
+    projects: 'ExpressionBuilder/ExpressionBuilder.csproj'
+    arguments: '--no-restore -c $(buildConfiguration) -o $(Build.ArtifactStagingDirectory)'
+
+- task: DotNetCoreCLI@2
+  displayName: 'Test'
+  inputs:
+    command: 'test'
+    projects: 'ExpressionBuilder/ExpressionBuilder.csproj'
+    arguments: '--no-restore -c $(buildConfiguration)'
+
+- task: PublishBuildArtifacts@1
+  displayName: 'Publish artifacts'
+  inputs:
+    PathtoPublish: '$(Build.ArtifactStagingDirectory)'
+    ArtifactName: 'drop'
+    publishLocation: 'Container'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -36,6 +36,14 @@ steps:
     command: 'test'
     projects: 'ExpressionBuilder/ExpressionBuilder.csproj'
     arguments: '--no-restore -c $(buildConfiguration)'
+    
+- task: DotNetCoreCLI@2
+  inputs:
+    command: 'pack'
+    packagesToPack: 'ExpressionBuilder/ExpressionBuilder.csproj'
+    versioningScheme: 'byEnvVar'
+    versionEnvVar: 'BUILD_BUILDNUMBER'
+    verbosityPack: 'Normal'
 
 - task: PublishBuildArtifacts@1
   displayName: 'Publish artifacts'


### PR DESCRIPTION
Proposed fix for https://github.com/dbelmont/ExpressionBuilder/issues/65

It appears that in .Net Core 3.1, the call would be confused between the standard string.Contains method and the System.Linq .Contains generic extension method. This issue can be resolved by making the GetMethod call more specific.